### PR TITLE
Potential fix for code scanning alert no. 12: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/solution.py
+++ b/Season-1/Level-5/solution.py
@@ -20,17 +20,17 @@ class Random_generator:
 
 class SHA256_hasher:
 
-    # produces the password hash by combining password + salt because hashing
+    # produces the password hash by combining password + salt using bcrypt
     def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
+        password_bytes = password.encode('utf-8')
+        password_hash = bcrypt.hashpw(password_bytes, salt)
         return password_hash.decode('ascii')
 
-    # verifies that the hashed password reverses to the plain text version on verification
+    # verifies that the hashed password matches the provided plain text password
     def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
+        password_bytes = password.encode('utf-8')
+        password_hash_bytes = password_hash.encode('ascii')
+        return bcrypt.checkpw(password_bytes, password_hash_bytes)
 
 # a collection of sensitive secrets necessary for the software to operate
 PRIVATE_KEY = os.environ.get('PRIVATE_KEY')


### PR DESCRIPTION
Potential fix for [https://github.com/Armode/skills-secure-code-game-odin/security/code-scanning/12](https://github.com/Armode/skills-secure-code-game-odin/security/code-scanning/12)

General fix: Avoid using a general-purpose fast hash (like SHA-256) as the effective password hashing mechanism. Instead, use a proper password hashing function (bcrypt is already present and appropriate here) directly on the password, and remove the SHA-256 step so passwords are not first processed by an algorithm that CodeQL flags as unsuitable for password hashing.

Concrete fix for this file:

- In `SHA256_hasher.password_hash`, stop computing `password = binascii.hexlify(hashlib.sha256(password.encode()).digest())` and instead encode the raw password to bytes and pass that directly to `bcrypt.hashpw`. So `password` should become `password_bytes = password.encode('utf-8')`, and the input to `bcrypt.hashpw` should be `password_bytes`.
- In `SHA256_hasher.password_verification`, do the same: remove the SHA-256-based transformation and encode the provided password directly to bytes before calling `bcrypt.checkpw`.
- No functional change to return types: keep returning the bcrypt hash as an ASCII string in `password_hash`, and keep taking/using it as such in `password_verification`.
- These changes are all within `Season-1/Level-5/solution.py`; no new imports are needed, and the existing `hashlib` and `binascii` imports can remain even if unused (you may later remove them if desired, but that is not required for the security fix).

This preserves the use of bcrypt (the correct password hashing primitive here) while eliminating the unnecessary SHA-256 step that CodeQL reports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
